### PR TITLE
Initial pytest configuration to run simply run pytest from the command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 vscode/
 build/
 PyFVTool.egg-info/
+local/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,21 +1,21 @@
 [build-system]
-requires = ["setuptools>=61.0", "numpy", "scipy", "matplotlib"]
+requires = ["setuptools>=61.0", "numpy", "scipy>=1.8.0", "matplotlib"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyfvtool"
-version = "0.0.1"
+version = "0.1"
 authors = [
   { name="Ali A. Eftekhari", email="e.eftekhari@gmail.com" },
 ]
-description = "A Finite Volume Tool in Python"
+description = "A finite volume tool in Python"
 readme = "README.md"
-requires-python = ">=3.5"
+requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Development Status :: 3 - Alpha",
+    "Development Status :: Beta",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Mathematics"
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,37 @@
+# Initial pytest configuration file for PyFVTool
+#
+# This allows tests to be run by simpling invoking
+#     `pytest`
+# from the command line, when in the `pyfvtool` project root directory.
+#
+# Running tests requires to have additionally installed
+# - `pytest`
+# - `pytest_notebook` (mind the underscore, do not use dash)
+# e.g.
+# `mamba install pytest pytest_notebook`
+# (or using `pip`)
+#
+# If you do not have `pytest_notebook` and Jupyter Notebook available,
+# it should be possible to run `pytest` nevertheless by removing the
+# `addopts = --nb-test-files` line below.
+#
+# The present pytest configuration scans all directories for files
+# named `test_*.py` or `*_test.py, or `*.ipynb` (Notebooks). These
+# will be considered "tests".
+#
+# pytest runs tests from `unittest`, and furthermore runs all "test"
+# scripts found. 
+#
+# **PLEASE NOTE!** If a script creates matplotlib graph windows, 
+# these windows need to be closed manually in order for test execution
+# to continue.
+#
+# Configuration may be fine-tuned as we go. The intention is to keep
+# this configuration file as minimalist as possible.
+#
+# Further info:
+# https://docs.pytest.org/en/7.4.x/reference/customize.html#configuration-file-formats
+#
+[pytest]
+minversion = 6.0
+addopts = --nb-test-files


### PR DESCRIPTION
With #12 in mind, here is an initial configuration of pytest. It is just a simple `pytest.ini` with few options. The comments in that file should ultimately go into the chapter "development and testing" in the documentation).

This configuration allows for `pytest` to be simply run from the command line, without further specified options, while in the root PyFVTool directory. It runs the notebooks.

A few matplotlib windows are created by the scripts. These should be manually closed for the tests to complete.

Jupyter Notebooks are tested, and your `unittests`, too. And also other scripts named `test_*` etc.

I did not try to fix any test failures. This can be done later when there is time. The objective here is just to be able to invoke pytest.



(P.S. I got "3 failed, 3 passed, 4 warnings" with `pytest` exiting gracefully)
